### PR TITLE
Introduce release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,23 @@
-name: Test Plugin
+name: Release
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
 
 jobs:
+
   release:
-    name: Create Release
+    name: Build & Attach Zip
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://packagist.org/packages/kunoichi/virtual-member
+      url: ${{ github.event.release.html_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
@@ -28,31 +31,15 @@ jobs:
           node-version: '20'
 
       - name: Build Plugin
-        run: bash bin/build.sh ${{ github.ref }}
+        run: bash bin/build.sh ${{ github.event.release.tag_name }}
 
-      - name: Create Zip
+      - name: Zip Archive
         run: |
           mkdir ${{ github.event.repository.name }}
-          rsync -av --exclude=${{ github.event.repository.name }}  --exclude-from=.distignore ./ ./${{ github.event.repository.name }}/
-          zip -r ${{ github.event.repository.name }}.${{ github.ref_name }}.zip ./${{ github.event.repository.name }}
+          rsync -av --exclude=${{ github.event.repository.name }} --exclude-from=.distignore ./ ./${{ github.event.repository.name }}/
+          zip -r ./${{ github.event.repository.name }}.zip ./${{ github.event.repository.name }}
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
+      - name: Upload Release Asset
+        run: gh release upload "${{ github.event.release.tag_name }}" "./${{ github.event.repository.name }}.zip"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/${{ github.event.repository.name }}.${{ github.ref_name }}.zip
-          asset_name: ${{ github.event.repository.name }}.${{ github.ref_name }}.zip
-          asset_content_type: application/zip


### PR DESCRIPTION
## 概要

`virtual-member` に release-drafter を導入し、リリースワークフローを整理します。

## 変更内容

- **`.github/release-drafter.yml`（新規）**: release-drafter の設定を追加。ラベルに応じたカテゴリ分類（Features / Bug Fixes / Maintenance / Documentation）と、major/minor/patch のバージョン解決ルール（デフォルト patch）を定義。
- **`.github/workflows/release-drafter.yml`（新規）**: master への push および PR 時にリリースドラフトを自動更新するワークフローを追加。
- **`.github/workflows/release.yml`（変更）**: トリガーを tag push から `release: published` に変更。自前の `create-release` をやめ、release 公開時にビルドした zip を `gh release upload` で添付する方式に統一。ワークフロー名も誤っていた "Test Plugin" から "Release" に修正。

## 運用フロー

1. master への push / PR で release-drafter がドラフトを自動更新
2. ドラフトを publish すると release.yml が起動し、zip をビルドしてリリースに添付